### PR TITLE
fix typo in RichContent method for adding a conversation part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix typo in conversation
 
 ## [1.2.0] - 2019-02-22
 - Add multichannel options

--- a/CM.Text/BusinessMessaging/MessageBuilder.cs
+++ b/CM.Text/BusinessMessaging/MessageBuilder.cs
@@ -85,7 +85,7 @@ namespace CM.Text.BusinessMessaging
             if (this._richContent == null)
                 this._richContent = new RichContent();
 
-            this._richContent.AddConversionPart(richMessage);
+            this._richContent.AddConversationPart(richMessage);
             return this;
         }
 

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/RichContent.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/RichContent.cs
@@ -36,7 +36,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         ///     Adds a message, such as a <see cref="RichCard" /> or <see cref="TextMessage" />.
         /// </summary>
         /// <param name="part"></param>
-        public void AddConversionPart(IRichMessage part)
+        public void AddConversationPart(IRichMessage part)
         {
             if (this.Conversation == null)
                 this.Conversation = new[] {part};


### PR DESCRIPTION
I noticed a typo in the naming of the method that adds a new part to the Conversation array