### PR TITLE
updated the WhatsApp Template Signature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2020-08-26
+- Removed Localizable Params because it is Deprecated by Facebook,
+Also updated the WhatsApp Template Signature based on Facebook spec updates.
+
+
 ## [1.8.0] - 2020-06-24
 - Add Twitter support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.9.0] - 2020-08-26
+## [2.0.0] - 2020-08-26
 - Removed Localizable Params because it is Deprecated by Facebook,
 Also updated the WhatsApp Template Signature based on Facebook spec updates.
 

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -164,7 +164,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
             Month = moment.Month;
             Year = moment.Year;
             DayOfMonth = moment.Day;
-            DayOfWeek = (int)moment.DayOfWeek;
+            DayOfWeek = (int)(moment.DayOfWeek + 6) % 7 + 1;
         }
     }
 

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -89,7 +89,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class TemplateCurrency
     {
         /// <summary>
-        /// Currency code, for example USD or EUR
+        /// The Fallback amount
         /// </summary>
         [JsonProperty("fallback_value")]
         public string FallbackValue { get; set; }
@@ -114,7 +114,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class TemplateDateTime
     {
         /// <summary>
-        /// The fallback date
+        /// The fallback date in UTC format
         /// </summary>
         /// <remarks>There will be no checking whether this is correct,</remarks>
         [JsonProperty("fallback_value")]

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -167,7 +167,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
             Month = moment.Month;
             Year = moment.Year;
             DayOfMonth = moment.Day;
-            DayOfWeek = (int)(moment.DayOfWeek + 6) % 7 + 1;
+            DayOfWeek  = moment.DayOfWeek == System.DayOfWeek.Friday ? 7 : (int)moment.DayOfWeek;
         }
     }
 

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -38,13 +38,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         [JsonProperty("language")]
         public Language Language { get; set; }
 
-        /// <summary>
-        /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
-        /// This field is an array of values to apply to variables in the template
-        /// </summary>
-        [JsonProperty("localizable_params")]
-        public LocalizableParam[] LocalizableParams { get; set; }
-
+   
         /// <summary>
         /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
         /// This field is an array of values to apply to variables in the template
@@ -97,7 +91,13 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// <summary>
         /// Currency code, for example USD or EUR
         /// </summary>
-        [JsonProperty("currency_code")]
+        [JsonProperty("fallback_value")]
+        public string FallbackValue { get; set; }
+
+        /// <summary>
+        /// Currency code, for example USD or EUR
+        /// </summary>
+        [JsonProperty("code")]
         public string CurrencyCode { get; set; }
 
         /// <summary>
@@ -114,33 +114,18 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class TemplateDateTime
     {
         /// <summary>
-        /// The date component as described in https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
+        /// The fallback date
         /// </summary>
-        [JsonProperty("component")]
-        public TemplateDateTimeComponent Component { get; }
+        /// <remarks>There will be no checking whether this is correct,</remarks>
+        [JsonProperty("fallback_value")]
+        public string FallbackValue { get; }
 
-        /// <summary>
-        /// Constructor initializing the component.
-        /// </summary>
-        /// <param name="moment"></param>
-        public TemplateDateTime(DateTime moment)
-        {
-            Component = new TemplateDateTimeComponent(moment);
-        }
-    }
-
-    /// <summary>
-    /// Used to localize a date time as described in
-    /// https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
-    /// </summary>
-    public class TemplateDateTimeComponent
-    {
         /// <summary>
         /// The day of the week.
         /// </summary>
         /// <remarks>There will be no checking whether this is correct,</remarks>
         [JsonProperty("day_of_week")]
-        public string DayOfWeek { get; }
+        public int DayOfWeek { get; }
         /// <summary>
         /// The day of the month.
         /// </summary>
@@ -168,19 +153,22 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         public int Minute { get; }
 
         /// <summary>
-        /// Constructor initializing the values.
+        /// Constructor initializing the component.
         /// </summary>
         /// <param name="moment"></param>
-        public TemplateDateTimeComponent(DateTime moment)
+        public TemplateDateTime(DateTime moment)
         {
+            FallbackValue = moment.ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
             Minute = moment.Minute;
             Hour = moment.Hour;
             Month = moment.Month;
             Year = moment.Year;
             DayOfMonth = moment.Day;
-            DayOfWeek = moment.DayOfWeek.ToString();
+            DayOfWeek = (int)moment.DayOfWeek;
         }
     }
+
+   
     /// <summary>
     /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
     /// The language parameter sets the language policy for an Message Template;
@@ -241,5 +229,29 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// </summary>
         [JsonProperty("media")]
         public MediaContent Media { get; set; }
+
+        /// <summary>
+        /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
+        /// 
+        /// Default text if localization fails
+        /// </summary>
+        [JsonProperty("default")]
+        public string Default { get; set; }
+
+        /// <summary>
+        /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
+        /// 
+        /// If the currency object is used, it contains required parameters currency_code and amount_1000.
+        /// </summary>
+        [JsonProperty("currency")]
+        public TemplateCurrency Currency { get; set; }
+
+        /// <summary>
+        /// Source: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates
+        /// 
+        /// If the date_time object is used, further definition of the date and time is required. 
+        /// </summary>
+        [JsonProperty("date_time")]
+        public TemplateDateTime DateTime { get; set; }
     }
 }

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -121,7 +121,10 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         public string FallbackValue { get; }
 
         /// <summary>
-        /// The day of the week.
+        /// The day of the week as specified in Facebook documentation
+        /// Options: "MONDAY", 1, "TUESDAY", 2, "WEDNESDAY", 3, "THURSDAY", 4, "FRIDAY", 5, "SATURDAY", 6, "SUNDAY", 7
+        /// see https://developers.facebook.com/docs/whatsapp/message-templates/localization
+        /// 
         /// </summary>
         /// <remarks>There will be no checking whether this is correct,</remarks>
         [JsonProperty("day_of_week")]

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -17,6 +17,8 @@
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyVersion>1.9.0.0</AssemblyVersion>
+    <FileVersion>1.9.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -17,8 +17,8 @@
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>1.9.0.0</AssemblyVersion>
-    <FileVersion>1.9.0.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ builder
       Code = "en",
        Policy = "deterministic"
      },
-     LocalizableParams = new LocalizableParam[] {},
      Components = new TemplateComponents[] {
       new TemplateComponents() {
        Type = "body",
@@ -126,7 +125,6 @@ builder
       Code = "en",
        Policy = "deterministic"
      },
-     LocalizableParams = new LocalizableParam[] {},
      Components = new TemplateComponents[] {
       new TemplateComponents() {
         Type = "header",
@@ -157,7 +155,67 @@ builder
 var message = builder.Build();
 var result = await client.SendMessageAsync(message);
 ```
+## Sending a WhatsApp template message with date and Currency
+It is also possible to send a rich template with an currency and an date!			
+			
+```cs
+var apiKey = new Guid(ConfigurationManager.AppSettings["ApiKey"]);
+var client = new TextClient(apiKey);
+var builder = new MessageBuilder("Message Text", "Sender_name", "0031636170815");
+ builder
+ .WithAllowedChannels(Channel.WhatsApp)
+ .WithTemplate(new TemplateMessage() {
+  Content = new TemplateMessageContent() {
+   Whatsapp = new WhatsappTemplate() {
+                            Name = "template-name",
+                            Namespace = "the-namespace-of-template",
+                            Language = new Language()
+                            {
+                                Code = "en",
+                                Policy = "deterministic"
+                            },
+                            Components = new TemplateComponents[] {
+                                new TemplateComponents() {
+                                    Type = "header",
+                                    ComponentParameters = new ComponentParameters[] {
+                                        new ComponentParameters() {
+                                            Type = "image",
+                                            Media = new MediaContent() {
+                                                MediaName = "cm.com",
+                                                MediaUri = "https://avatars3.githubusercontent.com/u/8234794?s=200&v=4"
+                                            },
+                                        }
+                                    }
+                                },
+                                new TemplateComponents()
+                                {
+                                    Type = "body",
+                                    ComponentParameters = new ComponentParameters[]
+                                    {
+                                        new ComponentParameters()
+                                       {
+                                           Type = "currency",
+                                           Currency = new TemplateCurrency()
+                                           {
+                                               FallbackValue = "$100.99",
+                                               Amount = 100990,
+                                               CurrencyCode = "USD"
+                                           }
+                                       },
+                                       new ComponentParameters()
+                                       {
+                                           Type = "date_time",
+                                           DateTime = new TemplateDateTime(DateTime.Now)
+                                       }
+                                    }}
+                            }
+                        }
+                    }
+                });
 
+   var message = builder.Build();
+   var result = await client.SendMessageAsync(message);
+```
 ## Sending an Apple Pay Request
 It is now possible to send an apple pay request only possible in Apple Business Chat
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ var message = builder.Build();
 var result = await client.SendMessageAsync(message);
 ```
 ## Sending a WhatsApp template message with date and Currency
-It is also possible to send a rich template with an currency and an date!			
+It is also possible to send a rich template with an currency and an date!
+please note that the timezone is in UTC format		
 			
 ```cs
 var apiKey = new Guid(ConfigurationManager.AppSettings["ApiKey"]);

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ It is also possible to send a rich template with an currency and an date!
 ```cs
 var apiKey = new Guid(ConfigurationManager.AppSettings["ApiKey"]);
 var client = new TextClient(apiKey);
-var builder = new MessageBuilder("Message Text", "Sender_name", "0031636170815");
+var builder = new MessageBuilder("Message Text", "Sender_name", "Recipient_PhoneNumber");
  builder
  .WithAllowedChannels(Channel.WhatsApp)
  .WithTemplate(new TemplateMessage() {


### PR DESCRIPTION
Removed Localizable Params because it is Deprecated by Facebook,
Also updated the WhatsApp Template Signature based on Facebook spec updates.

Added an example on how to send an template with datetime and currency