### PR TITLE
Adhere to BM Reply suggestion spec

### DIFF
--- a/CM.Text/BusinessMessaging/Model/MultiChannel/ReplySuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/ReplySuggestion.cs
@@ -14,5 +14,23 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// </summary>
         [JsonProperty("action")]
         public override string Action => "reply";
+
+        /// <summary>
+        ///     Description of the Reply suggestion
+        /// </summary>
+        /// <remarks>
+        ///     For <see cref="Channel.Twitter" />
+        /// </remarks>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        ///     The thumbnail image of the Reply suggestion
+        /// </summary>
+        /// <remarks>
+        ///     For <see cref="Channel.FacebookMessenger" />
+        /// </remarks>
+        [JsonProperty("media")]
+        public MediaContent Media { get; set; }
     }
 }


### PR DESCRIPTION
This pull request adds the properties `description` and `media` to the Reply suggestion as specified under [the RichContent header of the BM API docs](https://www.cm.com/app/docs/en/api/business-messaging-api/1.0/index#rich-content).