### PR TITLE
Proper JSON formatting for MediaContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2021-05-25
+- Correct JSON formatting of MediaContent
+
 ## [2.0.4] - 2021-05-20
 - Added media en description to ReplySuggestion
 

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/MediaContent.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/MediaContent.cs
@@ -31,16 +31,19 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// <summary>
         ///     The name of the image, audio or video.
         /// </summary>
+        [JsonProperty("mediaName")]
         public string MediaName { get; set; }
 
         /// <summary>
         ///     The location of the image, audio or video.
         /// </summary>
+        [JsonProperty("mediaUri")]
         public string MediaUri { get; set; }
 
         /// <summary>
         ///     The mimetype of the image, audio or video.
         /// </summary>
+        [JsonProperty("mimeType")]
         public string MimeType { get; set; }
     }
 }

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/MediaContent.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/MediaContent.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using Newtonsoft.Json;
 
 namespace CM.Text.BusinessMessaging.Model.MultiChannel
 {

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -12,13 +12,13 @@
     <Copyright>2020 CM.com</Copyright>
     <PackageLicenseUrl>https://mit-license.org</PackageLicenseUrl>
     <PackageReleaseNotes>See CHANGELOG.md for details</PackageReleaseNotes>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
     <PackageIconUrl>http://static.cmtelecom.com/images/cm-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>2.0.4.0</AssemblyVersion>
-    <FileVersion>2.0.4.0</FileVersion>
+    <AssemblyVersion>2.0.5.0</AssemblyVersion>
+    <FileVersion>2.0.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `MediaContent` class is missing JsonProperty annotations which results in the serialized JSON having a mix of pascal case and camel case. This PR makes sure they are compatible with the camel casing used in the rest of the classes.