### PR TITLE
Fixed several marked issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2021-07-08
+- Ignore HybridAppKey when null instead of empty, to support Notifire flow of channel MobilePush
+- Add DefaultValueHandling to RichContent property of Message model.
+- Add Tag property to TextMessage model used within a rich message.
+- Add Suggestions property to TextMessage model used within a rich message.
+- Add AppleBusinessChat as channel type, and marked iMessage as obsolete.
+
 ## [2.0.5] - 2021-05-25
 - Correct JSON formatting of MediaContent
 
@@ -21,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2020-08-26
 - Removed Localizable Params because it is Deprecated by Facebook,
-Also updated the WhatsApp Template Signature based on Facebook spec updates.
+- Also updated the WhatsApp Template Signature based on Facebook spec updates.
 
 ## [1.8.0] - 2020-06-24
 - Add Twitter support

--- a/CM.Text/BusinessMessaging/Model/Channel.cs
+++ b/CM.Text/BusinessMessaging/Model/Channel.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 
 namespace CM.Text.BusinessMessaging.Model
@@ -63,8 +64,18 @@ namespace CM.Text.BusinessMessaging.Model
         /// <remarks>
         ///     Note that CM needs to configure this for you to work.
         /// </remarks>
+        [Obsolete("Use 'Channel.AppleBusinessChat' instead")]
         // ReSharper disable once InconsistentNaming
         iMessage,
+
+        /// <summary>
+        ///     Messages will be sent over Apple Business Chat.
+        /// </summary>
+        /// <remarks>
+        ///     Note that CM needs to configure this for you to work.
+        /// </remarks>
+        [EnumMember(Value = "Apple Business Chat")]
+        AppleBusinessChat,
 
         /// <summary>
         ///     Messages will be sent over Line.

--- a/CM.Text/BusinessMessaging/Model/Message.cs
+++ b/CM.Text/BusinessMessaging/Model/Message.cs
@@ -85,7 +85,7 @@ namespace CM.Text.BusinessMessaging.Model
         ///     Messages will be sent over the <see cref="Channel.Push" /> channel.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, PropertyName = "appKey")]
-        public Guid HybridAppKey { get; set; }
+        public Guid? HybridAppKey { get; set; }
 
         /// <summary>
         ///     Used when sending multipart or concatenated SMS messages and always used together with
@@ -132,6 +132,7 @@ namespace CM.Text.BusinessMessaging.Model
         ///     Can be used by channels that support rich content (all channels except <see cref="Channel.SMS" />,
         ///     <see cref="Channel.Voice" /> and <see cref="Channel.Push" /> at this moment)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, PropertyName = "richContent")]
         public RichContent RichContent { get; set; }
 
         /// <summary>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/TextMessage.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/TextMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Newtonsoft.Json;
 
 namespace CM.Text.BusinessMessaging.Model.MultiChannel
@@ -45,22 +44,5 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// </summary>
         [JsonProperty("suggestions")]
         public SuggestionBase[] Suggestions { get; set; }
-
-        /// <summary>
-        ///     Adds a suggestion
-        /// </summary>
-        /// <param name="suggestion"></param>
-        public void AddSuggestion(SuggestionBase suggestion)
-        {
-            if (this.Suggestions == null)
-                this.Suggestions = new[] { suggestion };
-            else
-            {
-                var newArr = this.Suggestions;
-                Array.Resize(ref newArr, this.Suggestions.Length + 1);
-                newArr[newArr.Length - 1] = suggestion;
-                this.Suggestions = newArr;
-            }
-        }
     }
 }

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/TextMessage.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/TextMessage.cs
@@ -1,12 +1,12 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 
 namespace CM.Text.BusinessMessaging.Model.MultiChannel
 {
     /// <summary>
-    ///     A regular text message, replaces the <see cref="Message.Body" /> for channels
-    ///     that support rich content (all channels except <see cref="Channel.SMS" />, <see cref="Channel.Voice" />
-    ///     and <see cref="Channel.Push" /> at this moment)
+    ///     A regular text message, replaces the <see cref="Message.Body" /> for channels that support rich content
+    ///     (all channels except <see cref="Channel.SMS" />, <see cref="Channel.Voice" /> and <see cref="Channel.Push" /> at this moment)
     /// </summary>
     [PublicAPI]
     public class TextMessage : IRichMessage
@@ -28,11 +28,39 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         }
 
         /// <summary>
-        /// A plain text message, when used it replaces the 'SMS' body text.
-        /// In <see cref="Channel.RCS"/>, when used in combination with an header and/or media this
-        /// will be set as the text of a rich card.
+        ///     A plain text message, when used it replaces the 'SMS' body text.
+        ///     In <see cref="Channel.RCS"/>, when used in combination with an header and/or media this will be set as the text of a rich card.
         /// </summary>
         [JsonProperty("text")]
         public string Text { get; set; }
+
+        /// <summary>
+        ///     Tag to send important and/or personally relevant 1:1 updates to recipients. E.g. to notify a recipient of an update on a recent purchase.
+        /// </summary>
+        [JsonProperty("tag")]
+        public string Tag { get; set; }
+
+        /// <summary>
+        ///     The suggestions of a text message.
+        /// </summary>
+        [JsonProperty("suggestions")]
+        public SuggestionBase[] Suggestions { get; set; }
+
+        /// <summary>
+        ///     Adds a suggestion
+        /// </summary>
+        /// <param name="suggestion"></param>
+        public void AddSuggestion(SuggestionBase suggestion)
+        {
+            if (this.Suggestions == null)
+                this.Suggestions = new[] { suggestion };
+            else
+            {
+                var newArr = this.Suggestions;
+                Array.Resize(ref newArr, this.Suggestions.Length + 1);
+                newArr[newArr.Length - 1] = suggestion;
+                this.Suggestions = newArr;
+            }
+        }
     }
 }

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -12,13 +12,13 @@
     <Copyright>2020 CM.com</Copyright>
     <PackageLicenseUrl>https://mit-license.org</PackageLicenseUrl>
     <PackageReleaseNotes>See CHANGELOG.md for details</PackageReleaseNotes>
-    <Version>2.0.5</Version>
+    <Version>2.1.0</Version>
     <PackageIconUrl>http://static.cmtelecom.com/images/cm-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>2.0.5.0</AssemblyVersion>
-    <FileVersion>2.0.5.0</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Ignore HybridAppKey when null instead of empty, to support Notifire flow of channel MobilePush
- Add DefaultValueHandling to RichContent property of Message model.
- Add Tag property to TextMessage model used within a rich message.
- Add Suggestions property to TextMessage model used within a rich message.
- Add AppleBusinessChat as channel type, and marked iMessage as obsolete.