### PR TITLE
Add support for end point overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add support for a custom end point URI
+
 ## [2.3.0] - 2021-10-27
 - Add TextClientFactory
 

--- a/CM.Text/TextClientFactory.cs
+++ b/CM.Text/TextClientFactory.cs
@@ -25,20 +25,23 @@ namespace CM.Text
     public class TextClientFactory : ITextClientFactory
     {
         private readonly HttpClient _httpClient;
+        [CanBeNull] private readonly Uri _endPointOverride;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextClientFactory"/> class.
         /// </summary>
         /// <param name="httpClient">The HTTP client.</param>
-        public TextClientFactory(HttpClient httpClient)
+        /// <param name="endPointOverride">(Optional) The end point to use, instead of the default "https://gw.cmtelecom.com/v1.0/message".</param>
+        public TextClientFactory(HttpClient httpClient, Uri endPointOverride = null)
         {
             this._httpClient = httpClient;
+            this._endPointOverride = endPointOverride;
         }
 
         /// <inheritdoc />
         public ITextClient GetClient(Guid productToken)
         {
-            return new TextClient(productToken, this._httpClient);
+            return new TextClient(productToken, this._httpClient, this._endPointOverride);
         }
     }
 }


### PR DESCRIPTION
Adds support for custom endpoints.

`var client = new TextClient(apiKey);`
can now be extended to
`var client = new TextClient(apiKey, myCustomUri);`

For the TextClient, the original constructor remains for binary compatibility.
In the TextClientFactory, the constructor is extended with an optional parameter. Since its use is typical for Dependency Injection, introducing multiple public constructors is not advised.
