### PR TITLE
Add Telegram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add Telegram
+
 ## [2.4.1] - 2022-02-01
 - Fix support for a custom end point URI in second SendMessage method
 

--- a/CM.Text/BusinessMessaging/Model/Channel.cs
+++ b/CM.Text/BusinessMessaging/Model/Channel.cs
@@ -128,5 +128,14 @@ namespace CM.Text.BusinessMessaging.Model
         /// </remarks>
         [EnumMember(Value = "Instagram")]
         Instagram,
+        
+        /// <summary>
+        ///     Messages will be sent over Telegram.
+        /// </summary>
+        /// <remarks>
+        ///     Note that CM needs to configure this for you to work.
+        /// </remarks>
+        [EnumMember(Value = "Telegram Messenger")]
+        Telegram,
     }
 }

--- a/CM.Text/TextClient.cs
+++ b/CM.Text/TextClient.cs
@@ -21,13 +21,13 @@ namespace CM.Text
         /// </summary>
         /// <param name="messageText">The message text.</param>
         /// <param name="from">
-        ///     This is the sender name. The maximum length is 11 alphanumerical characters or 16 digits. Example:
-        ///     'MyCompany'.<br/>
+        ///     This is the sender name. The maximum length is 11 alphanumerical characters or 16 digits. Example: 'MyCompany'.<br/>
         ///     For Twitter: use the Twitter Snowflake ID of the account you want to use as sender.<br/>
         ///     For MobilePush: use the app key of the account you want to use as sender.<br/>
         ///     For Facebook Messenger: use the Facebook Page ID of the account you want to use as sender.<br/>
         ///     For Google Business Messages: use the Google Business Messages agent ID of the account you want to use as sender (without dashes).<br/>
-        ///     For Instagram: use the Instagram Account ID of the account you want to use as sender.
+        ///     For Instagram: use the Instagram Account ID of the account you want to use as sender.<br/>
+        ///     For Telegram: use the Telegram Bot ID of the account you want to use as sender.
         /// </param>
         /// <param name="to">
         ///     These are the destination mobile numbers. Restrictions: this value should be in international format.
@@ -35,7 +35,8 @@ namespace CM.Text
         ///     For Twitter: use the Twitter Snowflake ID.<br/>
         ///     For Facebook Messenger: use the Facebook Page Scoped User ID (PSID).<br/>
         ///     For Google Business Messages: use the Google Business Messages conversation ID (without dashes).<br/>
-        ///     For Instagram: use the Instagram Scoped User ID (IGSID).
+        ///     For Instagram: use the Instagram Scoped User ID (IGSID).<br/>
+        ///     For Telegram: use the Telegram Chat ID.
         /// </param>
         /// <param name="reference">
         ///     Here you can include your message reference. This information will be returned in a status


### PR DESCRIPTION
Add the channel type Telegram (encoded as `Telegram Messenger`) and the related informational descriptions on Bot ID and Chat ID.