### PR TITLE
[2.5.2] Enable package generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2] - 2022-10-14
+- Enable nupkg generation in project
+
 ## [2.5.1] - 2022-10-12
 - Upped Newtonsoft.Json
 

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -9,16 +9,17 @@
     <PackageTags>messaging, text, sms, email, push, whatsapp, viber, wechat, rcs, voice, business messaging, telegram, conversational, sms chat, chat, sms 2.0, rbm, mms, rich sms, rich communication services</PackageTags>
     <RepositoryUrl>https://github.com/cmdotcom/text-sdk-dotnet</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
-    <Copyright>2020 CM.com</Copyright>
+    <Copyright>2022 CM.com</Copyright>
     <PackageLicenseUrl>https://mit-license.org</PackageLicenseUrl>
     <PackageReleaseNotes>See CHANGELOG.md for details</PackageReleaseNotes>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <PackageIconUrl>http://static.cmtelecom.com/images/cm-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>2.5.1.0</AssemblyVersion>
-    <FileVersion>2.5.1.0</FileVersion>
+    <AssemblyVersion>2.5.2.0</AssemblyVersion>
+    <FileVersion>2.5.2.0</FileVersion>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Relativly simple, enabled .nupkg generation as the old pipeline used dotnet pack.