### PR TITLE
Add polymorphic type discriminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - TBD
+## [2.10.0] - 2024-12-30
 ### Added
 - Polymorphic type discriminators on IRichMessage for deserialization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.10.0] - TBD
+### Added
+- Polymorphic type discriminators on IRichMessage for deserialization
+
 ### Changed
 - Updated `System.Text.Json` to 8.0.5 fixing a [high impact security vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - TBD
+### Changed
+- Updated `System.Text.Json` to 8.0.5 fixing a [high impact security vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)
+
 ## [2.9.0] - 2024-06-20
 ### Changed
 - New global messaging endpoint

--- a/CM.Text.Tests/DeserializationTests.cs
+++ b/CM.Text.Tests/DeserializationTests.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using CM.Text.BusinessMessaging.Model.MultiChannel;
+using FluentAssertions;
+
+namespace CM.Text.Tests
+{
+    [TestClass]
+    public class DeserializationTests
+    {
+        [TestMethod]
+        public void DeserializeTextTest()
+        {
+            var textMessage = "{\"$type\":\"TextMessage\",\"text\":\"testing correct deserialization\",\"tag\":null,\"suggestions\":null}";
+            var deserialized = JsonSerializer.Deserialize<IRichMessage>(textMessage);
+
+            deserialized.Should().BeOfType<TextMessage>();
+            var deserializedTextMessage = deserialized as TextMessage;
+            deserializedTextMessage!.Text.Should().Be("testing correct deserialization");
+        }
+    }
+}
+
+

--- a/CM.Text.Tests/SerializationTests.cs
+++ b/CM.Text.Tests/SerializationTests.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using CM.Text.BusinessMessaging.Model.MultiChannel;
+using FluentAssertions;
+
+namespace CM.Text.Tests
+{
+    [TestClass]
+    public class SerializationTests
+    {
+        [TestMethod]
+        public void SerializeTextTest()
+        {
+            var textMessage = new TextMessage("testing correct serialization");
+            var serialized= JsonSerializer.Serialize<IRichMessage>(textMessage);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            serialized.Should().Contain("\"$type\":\"TextMessage\"");
+        }
+    }
+}

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/IRichMessage.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/IRichMessage.cs
@@ -8,14 +8,14 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     /// Requires a json derived type for serialization to work
     /// </summary>
     [PublicAPI]
-    [JsonDerivedType(typeof(MediaMessage))]
-    [JsonDerivedType(typeof(ApplePayRequest))]
-    [JsonDerivedType(typeof(CarouselMessage))]
-    [JsonDerivedType(typeof(ContactMessage))]
-    [JsonDerivedType(typeof(LocationPushMessage))]
-    [JsonDerivedType(typeof(TemplateMessage))]
-    [JsonDerivedType(typeof(TextMessage))]
-    [JsonDerivedType(typeof(WhatsAppInteractiveMessage))]
+    [JsonDerivedType(typeof(MediaMessage), nameof(MediaMessage))]
+    [JsonDerivedType(typeof(ApplePayRequest), nameof(ApplePayRequest))]
+    [JsonDerivedType(typeof(CarouselMessage), nameof(CarouselMessage))]
+    [JsonDerivedType(typeof(ContactMessage), nameof(ContactMessage))]
+    [JsonDerivedType(typeof(LocationPushMessage), nameof(LocationPushMessage))]
+    [JsonDerivedType(typeof(TemplateMessage), nameof(TemplateMessage))]
+    [JsonDerivedType(typeof(TextMessage), nameof(TextMessage))]
+    [JsonDerivedType(typeof(WhatsAppInteractiveMessage), nameof(WhatsAppInteractiveMessage))]
     public interface IRichMessage
     {
     }

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -63,7 +63,7 @@
     </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
     <ItemGroup>

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -13,12 +13,12 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../CHANGELOG.md"))</PackageReleaseNotes>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>2.9.0</AssemblyVersion>
-    <FileVersion>2.9.0</FileVersion>
+    <AssemblyVersion>2.10.0</AssemblyVersion>
+    <FileVersion>2.10.0</FileVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
This change provides proper deserialization of derived classes, as documented by Microsoft [here](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism#polymorphic-type-discriminators).

I also updated System.Text.Json because of [a high impact security vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w). This was necessary for a working build anyway, because of the warnings as errors setting