### PR TITLE
Add JSON converter for mapping IRichMessage without type info

### DIFF
--- a/CM.Text.Tests/DeserializationTests.cs
+++ b/CM.Text.Tests/DeserializationTests.cs
@@ -17,6 +17,28 @@ namespace CM.Text.Tests
             var deserializedTextMessage = deserialized as TextMessage;
             deserializedTextMessage!.Text.Should().Be("testing correct deserialization");
         }
+
+        [TestMethod]
+        public void DeserializeTemplateMessageWithTypeTest()
+        {
+            var richContentJson =
+                "{\"conversation\": [{\"template\": {\"whatsapp\": {\"namespace\": \"some_identifier\",\"element_name\": \"image__link\",\"language\": {\"code\": \"en\",\"policy\": \"deterministic\"},\"components\": [{\"type\": \"header\",\"parameters\": [{\"type\": \"image\",\"media\": {\"mediaUri\": \"https://example.com/image.png\",\"mimeType\": \"image/jpeg\"}}]},{\"type\": \"body\",\"parameters\": [{\"type\": \"text\",\"text\": \"testing\"}]},{\"type\": \"button\",\"sub_type\": \"url\",\"index\": \"0\",\"parameters\": [{\"type\": \"text\",\"text\": \"whatsapp\"}]}]}}}]}";
+            var deserialized = JsonSerializer.Deserialize<RichContent>(richContentJson);
+            deserialized.Should().NotBeNull();
+            deserialized!.Conversation.FirstOrDefault().Should().BeOfType<TemplateMessage>();
+        }
+
+        [TestMethod]
+        public void DeserializeTextMessageWithTypeTest()
+        {
+            var richContentJson =
+                "{\"conversation\": [{\"text\": \"testing\"}]}";
+            var deserialized = JsonSerializer.Deserialize<RichContent>(richContentJson);
+            deserialized.Should().NotBeNull();
+            deserialized!.Conversation.FirstOrDefault().Should().BeOfType<TextMessage>();
+
+            var message = deserialized.Conversation.First();
+        }
     }
 }
 

--- a/CM.Text/BusinessMessaging/JsonConverters/RichMessageArrayJsonConverter.cs
+++ b/CM.Text/BusinessMessaging/JsonConverters/RichMessageArrayJsonConverter.cs
@@ -58,7 +58,6 @@ namespace CM.Text.BusinessMessaging.JsonConverters
                 }
                 else
                 {
-                    Console.WriteLine(JsonSerializer.Serialize(node));
                     throw new JsonException("Unsupported message type to deserialize");
                 }
 

--- a/CM.Text/BusinessMessaging/JsonConverters/RichMessageArrayJsonConverter.cs
+++ b/CM.Text/BusinessMessaging/JsonConverters/RichMessageArrayJsonConverter.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using CM.Text.BusinessMessaging.Model.MultiChannel;
+
+namespace CM.Text.BusinessMessaging.JsonConverters
+{
+    /// <summary>
+    /// JsonConverter used to deserialize array implementations of IRichMessage when no type information is present in the JSON
+    /// </summary>
+    public class RichMessageArrayJsonConverter : JsonConverter<IRichMessage[]>
+    {
+        /// <summary>
+        /// Deserializes to a RichMessage array implementation when no type info is present
+        /// (param descriptions taken from System.Text.Json.Serialization.JsonConverter)
+        /// </summary>
+        /// <param name="reader">The reader</param>
+        /// <param name="typeToConvert">The type to convert</param>
+        /// <param name="options">An object that specifies serialization options to use.</param>
+        /// <returns>The constructed implementation class array</returns>
+        /// <exception cref="JsonException">Thrown when no applicable implementation class can be found</exception>
+        public override IRichMessage[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("Expected start of array");
+            }
+
+            var messages = new List<IRichMessage>();
+            
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                if (reader.TokenType != JsonTokenType.StartObject)
+                {
+                    continue;
+                }
+
+                JsonNode node = JsonNode.Parse(ref reader);
+
+                if (node == null)
+                    throw new JsonException("Can't deserialize because JSON content is null");
+
+                IRichMessage message;
+                if (node["text"] != null)
+                {
+                    message = JsonSerializer.Deserialize<TextMessage>(node.ToJsonString(), options);
+                }
+                else if (node["template"] != null)
+                {
+                    message = JsonSerializer.Deserialize<TemplateMessage>(node.ToJsonString(), options);
+                }
+                else
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(node));
+                    throw new JsonException("Unsupported message type to deserialize");
+                }
+
+                messages.Add(message);
+            }
+
+            return messages.ToArray();
+        }
+
+        /// <summary>
+        /// Serializes a RichMessage array
+        /// (param descriptions taken from System.Text.Json.Serialization.JsonConverter)
+        /// </summary>
+        /// <param name="writer">The writer to write to</param>
+        /// <param name="value">The value to convert to JSON</param>
+        /// <param name="options">An object that specifies serialization options to use</param>
+        public override void Write(Utf8JsonWriter writer, IRichMessage[] value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (var message in value)
+            {
+                JsonSerializer.Serialize(writer, message, message.GetType(), options);
+            }
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/RichContent.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/RichContent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using CM.Text.BusinessMessaging.JsonConverters;
 using JetBrains.Annotations;
 
 namespace CM.Text.BusinessMessaging.Model.MultiChannel
@@ -24,6 +25,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         ///     The messages.
         /// </summary>
         [JsonPropertyName("conversation")]
+        [JsonConverter(typeof(RichMessageArrayJsonConverter))]
         public IRichMessage[] Conversation { get; set; }
 
         /// <summary>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/WhatsAppTemplate.cs
@@ -216,6 +216,7 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// You can have up to 3 buttons using index values of 0-2.
         /// </summary>
         [JsonPropertyName("index")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public int Index { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Our current use-case only applies to `Text` and `Template` message types. Due to a lack of time I didn't implement other message types at this moment.