### PR TITLE
Add derived types to Suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - TBD
+### Added
+- Derived type declarations on `SuggestionBase`
+
 ## [2.11.0] - 2025-01-10
 ### Added
 - Context.MessageId on RichMessages supporting WhatsApp for referencing a previous message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.11.1] - TBD
+## [2.11.1] - 2025-01-31
 ### Added
 - Derived type declarations on `SuggestionBase`
 

--- a/CM.Text.Tests/SuggestionsTests.cs
+++ b/CM.Text.Tests/SuggestionsTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using CM.Text.BusinessMessaging.Model.MultiChannel;
+using FluentAssertions;
+
+namespace CM.Text.Tests
+{
+    [TestClass]
+    public class SuggestionsTests
+    {
+        [TestMethod]
+        public void SerializationCalendarSuggestionTest()
+        {
+            var calenderSuggestion = new CalendarSuggestion()
+            {
+                Calendar = new CalendarOptions()
+                {
+                    Title = "Appointment selection",
+                    Description = "Schedule an appointment with us",
+                    EndTime = DateTime.UtcNow,
+                    StartTime = DateTime.UtcNow,
+                }
+            };
+            
+            var serialized= JsonSerializer.Serialize<SuggestionBase>(calenderSuggestion);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            
+            var deserialized = JsonSerializer.Deserialize<SuggestionBase>(serialized);
+
+            deserialized.Should().BeOfType<CalendarSuggestion>();
+            var deserializedCalendarSuggestion = deserialized as CalendarSuggestion;
+            deserializedCalendarSuggestion.Should().BeEquivalentTo(calenderSuggestion);
+        }
+        
+        [TestMethod]
+        public void SerializationDialSuggestionTest()
+        {
+            var dialSuggestion = new DialSuggestion()
+            {
+                Dial = new Dial()
+                {
+                    PhoneNumber = "0031612345678"
+                }
+            };
+            
+            var serialized= JsonSerializer.Serialize<SuggestionBase>(dialSuggestion);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            
+            var deserialized = JsonSerializer.Deserialize<SuggestionBase>(serialized);
+
+            deserialized.Should().BeOfType<DialSuggestion>();
+            var deserializedDialSuggestion = deserialized as DialSuggestion;
+            deserializedDialSuggestion.Should().BeEquivalentTo(dialSuggestion);
+        }
+        
+        [TestMethod]
+        public void SerializationOpenUrlSuggestionTest()
+        {
+            var openUrlSuggestion = new OpenUrlSuggestion()
+            {
+                Url = "https://www.cm.com"
+            };
+            
+            var serialized= JsonSerializer.Serialize<SuggestionBase>(openUrlSuggestion);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            
+            var deserialized = JsonSerializer.Deserialize<SuggestionBase>(serialized);
+
+            deserialized.Should().BeOfType<OpenUrlSuggestion>();
+            var deserializedOpenUrlSuggestion = deserialized as OpenUrlSuggestion;
+            deserializedOpenUrlSuggestion.Should().BeEquivalentTo(openUrlSuggestion);
+        }
+        
+        [TestMethod]
+        public void SerializationViewLocationSuggestionTest()
+        {
+            var viewLocationSuggestion = new ViewLocationSuggestion()
+            {
+                Location = new ViewLocationOptions()
+                {
+                    Label = "CM.com headquarters",
+                    Latitude = "51.602885",
+                    Longitude = "4.7683932",
+                    SearchQuery = "CM.com headquarters",
+                    Radius = 5
+                }
+            };
+            
+            var serialized= JsonSerializer.Serialize<SuggestionBase>(viewLocationSuggestion);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            
+            var deserialized = JsonSerializer.Deserialize<SuggestionBase>(serialized);
+
+            deserialized.Should().BeOfType<ViewLocationSuggestion>();
+            var deserializedViewLocationSuggestion = deserialized as ViewLocationSuggestion;
+            deserializedViewLocationSuggestion.Should().BeEquivalentTo(viewLocationSuggestion);
+        }
+        
+        [TestMethod]
+        public void SerializationReplySuggestionTest()
+        {
+            var replySuggestion = new ReplySuggestion()
+            {
+                Label = "Some label",
+                PostbackData = "LABEL",
+                Description = "Description of the label",
+                Media = new MediaContent("Test image", "https://example.com", "image/jpg")
+            };
+            var serialized= JsonSerializer.Serialize<SuggestionBase>(replySuggestion);
+
+            serialized.Should().NotBeNullOrWhiteSpace();
+            
+            var deserialized = JsonSerializer.Deserialize<SuggestionBase>(serialized);
+
+            deserialized.Should().BeOfType<ReplySuggestion>();
+            var deserializedReplySuggestion = deserialized as ReplySuggestion;
+            deserializedReplySuggestion.Should().BeEquivalentTo(replySuggestion);
+        }
+    }
+}

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/CalendarOptions.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/CalendarOptions.cs
@@ -13,12 +13,14 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
         /// <summary>
         ///     The end of the appointment.
         /// </summary>
-        [JsonPropertyName("endTime")] public DateTime EndTime;
+        [JsonPropertyName("endTime")]
+        public DateTime EndTime { get; set; }
 
         /// <summary>
         ///     The start of the appointment.
         /// </summary>
-        [JsonPropertyName("startTime")] public DateTime StartTime;
+        [JsonPropertyName("startTime")]
+        public DateTime StartTime { get; set; }
 
         /// <summary>
         ///     The description which will appear in the calendar app

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/CalendarSuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/CalendarSuggestion.cs
@@ -12,12 +12,6 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class CalendarSuggestion : SuggestionBase
     {
         /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public override string Action => "CreateCalendarEvent";
-
-        /// <summary>
         ///     The options of the agenda item
         /// </summary>
         [JsonPropertyName("calendar")]

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/DialSuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/DialSuggestion.cs
@@ -12,12 +12,6 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class DialSuggestion : SuggestionBase
     {
         /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public override string Action => "Dial";
-
-        /// <summary>
         ///     The dial options
         /// </summary>
         [JsonPropertyName("dial")]

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/OpenUrlSuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/OpenUrlSuggestion.cs
@@ -14,12 +14,6 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class OpenUrlSuggestion : SuggestionBase
     {
         /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public override string Action => "openUrl";
-
-        /// <summary>
         ///     The url the end user can open
         /// </summary>
         /// <remarks>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/ReplySuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/ReplySuggestion.cs
@@ -10,12 +10,6 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class ReplySuggestion : SuggestionBase
     {
         /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public override string Action => "reply";
-
-        /// <summary>
         ///     Description of the Reply suggestion
         /// </summary>
         /// <remarks>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/SuggestionBase.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/SuggestionBase.cs
@@ -6,8 +6,15 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     /// <summary>
     ///     Suggestions can be used in several channels, not all channels
     ///     support all suggestions.
+    ///
+    ///     Requires a json derived type for serialization to work
     /// </summary>
     [PublicAPI]
+    [JsonDerivedType(typeof(CalendarSuggestion), nameof(CalendarSuggestion))]
+    [JsonDerivedType(typeof(DialSuggestion), nameof(DialSuggestion))]
+    [JsonDerivedType(typeof(OpenUrlSuggestion), nameof(OpenUrlSuggestion))]
+    [JsonDerivedType(typeof(ReplySuggestion), nameof(ReplySuggestion))]
+    [JsonDerivedType(typeof(ViewLocationSuggestion), nameof(ViewLocationSuggestion))]
     public abstract class SuggestionBase
     {
         /// <summary>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/SuggestionBase.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/SuggestionBase.cs
@@ -10,19 +10,14 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     ///     Requires a json derived type for serialization to work
     /// </summary>
     [PublicAPI]
-    [JsonDerivedType(typeof(CalendarSuggestion), nameof(CalendarSuggestion))]
-    [JsonDerivedType(typeof(DialSuggestion), nameof(DialSuggestion))]
-    [JsonDerivedType(typeof(OpenUrlSuggestion), nameof(OpenUrlSuggestion))]
-    [JsonDerivedType(typeof(ReplySuggestion), nameof(ReplySuggestion))]
-    [JsonDerivedType(typeof(ViewLocationSuggestion), nameof(ViewLocationSuggestion))]
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "action")]
+    [JsonDerivedType(typeof(CalendarSuggestion), "CreateCalendarEvent")]
+    [JsonDerivedType(typeof(DialSuggestion), "Dial")]
+    [JsonDerivedType(typeof(OpenUrlSuggestion), "openUrl")]
+    [JsonDerivedType(typeof(ReplySuggestion), "reply")]
+    [JsonDerivedType(typeof(ViewLocationSuggestion), "viewLocation")]
     public abstract class SuggestionBase
     {
-        /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public virtual string Action { get; }
-
         /// <summary>
         ///     The text the end user will see
         /// </summary>

--- a/CM.Text/BusinessMessaging/Model/MultiChannel/ViewLocationSuggestion.cs
+++ b/CM.Text/BusinessMessaging/Model/MultiChannel/ViewLocationSuggestion.cs
@@ -10,12 +10,6 @@ namespace CM.Text.BusinessMessaging.Model.MultiChannel
     public class ViewLocationSuggestion : SuggestionBase
     {
         /// <summary>
-        ///     The action of this suggestion
-        /// </summary>
-        [JsonPropertyName("action")]
-        public override string Action => "viewLocation";
-
-        /// <summary>
         ///     The location options
         /// </summary>
         [JsonPropertyName("viewLocation")]

--- a/CM.Text/CM.Text.csproj
+++ b/CM.Text/CM.Text.csproj
@@ -13,12 +13,12 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../CHANGELOG.md"))</PackageReleaseNotes>
-    <Version>2.11.0</Version>
+    <Version>2.11.1</Version>
     <PackageProjectUrl>https://github.com/cmdotcom/text-sdk-dotnet</PackageProjectUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>2.11.0</AssemblyVersion>
-    <FileVersion>2.11.0</FileVersion>
+    <AssemblyVersion>2.11.1</AssemblyVersion>
+    <FileVersion>2.11.1</FileVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Derived types declarations (similar to [`IRichMessage`](https://github.com/cmdotcom/text-sdk-dotnet/blob/master/CM.Text/BusinessMessaging/Model/MultiChannel/IRichMessage.cs)) are missing on `BaseSuggestion`, breaking serialization. This is shown with a simple test ran against the current `master` branch:

```c#
[TestClass]
public class SuggestionsTests
{
  [TestMethod]
  public void SerializationReplySuggestionTest()
  {
      var replySuggestion = new ReplySuggestion()
      {
          Label = "Some label",
          PostbackData = "LABEL",
          Description = "Description of the label",
          Media = new MediaContent("Test image", "https://example.com", "image/jpg")
      };
      var serialized= JsonSerializer.Serialize<SuggestionBase>(replySuggestion);
  }
}
```

`serialized` will then look as follows, missing the `description` field and `media` object:

```json
{
  "action" : "reply",
  "label" : "Some label",
  "postbackdata" : "LABEL"
}
```

Couple extra notes:

* I've kept the casing and the discriminator itself consistent
* I've left in the `Description` field, though the summary says it only applies to Twitter which is now deprecated
* I've had to [add a getter and setter to `EndTime` and `StartTime` in `CalendarOptions`](https://github.com/cmdotcom/text-sdk-dotnet/pull/78/commits/abf379fba924c82cdc29c98dad6a0c9f401f1e07) for those fields to be picked up during serialization
* I'm considering this a patch version update since it's backwards compatible and fixes things that were previously overlooked